### PR TITLE
Add copy of the EmployeesApi OAS doc to the root for importing in new projects

### DIFF
--- a/EmployeesApi.yaml
+++ b/EmployeesApi.yaml
@@ -1,0 +1,415 @@
+openapi: 3.0.0
+info:
+  title: EmployeesApi
+  description: Employee management API for Db2.
+  version: "1.1"
+  license:
+    name: Apache-2.0
+    url: https://opensource.org/licenses/Apache-2.0
+servers:
+- url: /project
+- url: http://localhost:9080/
+- url: https://localhost:9443/
+security:
+- BasicAuth: []
+- BearerAuth: []
+paths:
+  /employees/{id}:
+    get:
+      tags:
+      - Edit
+      - Discover
+      summary: Get an employee
+      description: Uses the getEmployee Db2 z/OS asset
+      operationId: employeesIdGet
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmployeeBody'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmployeeNotFound'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    put:
+      tags:
+      - Edit
+      summary: Update an employee
+      description: Uses the updateEmployee Db2 z/OS asset
+      operationId: employeesIdPut
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmployeeBody'
+      responses:
+        "200":
+          description: Updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmployeeBody'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmployeeNotFound'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      tags:
+      - Edit
+      summary: Delete an employee
+      description: Uses the deleteEmployee Db2 z/OS asset
+      operationId: employeesIdDelete
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Deleted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmployeeNumber'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmployeeNotFound'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /employees:
+    get:
+      tags:
+      - Discover
+      summary: Get all employee details
+      description: Uses the getEmployees Db2 z/OS asset
+      operationId: employeesGet
+      parameters:
+      - name: department
+        in: cookie
+        required: false
+        style: form
+        explode: true
+        schema:
+          $ref: '#/components/schemas/Departments'
+      - name: job
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          $ref: '#/components/schemas/Job'
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/EmployeeBodyFormatted'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    post:
+      tags:
+      - Edit
+      summary: Add an employee
+      description: Uses the addEmployee Db2 z/OS asset
+      operationId: employeesPost
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmployeeBody'
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmployeeBody'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+components:
+  schemas:
+    EmployeeBody:
+      type: object
+      properties:
+        employeeNumber:
+          maxLength: 6
+          type: string
+        firstName:
+          maxLength: 12
+          type: string
+        middleInitial:
+          maxLength: 1
+          type: string
+        lastName:
+          maxLength: 15
+          type: string
+        department:
+          maxLength: 3
+          type: string
+        phoneNumber:
+          maxLength: 4
+          minLength: 4
+          type: string
+        hireDate:
+          type: string
+          format: date-time
+        job:
+          maxLength: 8
+          type: string
+        educationLevel:
+          type: integer
+        sex:
+          maxLength: 1
+          minLength: 1
+          type: string
+        dateOfBirth:
+          type: string
+          format: date-time
+        salary:
+          type: number
+          format: double
+        bonus:
+          type: number
+          format: double
+        commission:
+          type: number
+          format: double
+      example:
+        employeeNumber: "000010"
+        firstName: CHRISTINE
+        middleInitial: I
+        lastName: HAAS
+        department: A00
+        phoneNumber: "3978"
+        hireDate: 2000-01-01
+        job: PRES
+        educationLevel: 18
+        sex: F
+        dateOfBirth: 1933-08-14
+        salary: 52750.0
+        bonus: 1000.0
+        commission: 4220.0
+    EmployeeBodyFormatted:
+      type: object
+      properties:
+        summary:
+          $ref: '#/components/schemas/EmployeeSummary'
+        personal:
+          $ref: '#/components/schemas/EmployeePersonalDetails'
+        work:
+          $ref: '#/components/schemas/EmployeeWorkDetails'
+    EmployeeSummary:
+      type: object
+      properties:
+        bio:
+          maxLength: 100
+          type: string
+      example:
+        bio: Christine Haas was hired in 1965 at 32 years old and is paid a total
+          of $57970
+    EmployeePersonalDetails:
+      type: object
+      properties:
+        firstName:
+          maxLength: 12
+          type: string
+        middleInitial:
+          maxLength: 1
+          type: string
+        lastName:
+          maxLength: 15
+          type: string
+        sex:
+          maxLength: 1
+          minLength: 1
+          type: string
+        dateOfBirth:
+          type: string
+          format: date-time
+      example:
+        firstName: CHRISTINE
+        middleInitial: I
+        lastName: HAAS
+        sex: F
+        dateOfBirth: 1933-08-14
+    EmployeeWorkDetails:
+      type: object
+      properties:
+        employeeNumber:
+          maxLength: 6
+          type: string
+        department:
+          maxLength: 3
+          type: string
+        phoneNumber:
+          maxLength: 4
+          minLength: 4
+          type: string
+        hireDate:
+          type: string
+          format: date-time
+        job:
+          maxLength: 8
+          type: string
+        educationLevel:
+          type: integer
+        pay:
+          $ref: '#/components/schemas/EmployeeWorkPay'
+      example:
+        employeeNumber: "000010"
+        department: A00
+        phoneNumber: "3978"
+        hireDate: 2000-01-01
+        job: PRES
+        educationLevel: 18
+        pay:
+          salary: 52750.0
+          bonus: 1000.0
+          commission: 4220.0
+    EmployeeWorkPay:
+      type: object
+      properties:
+        salary:
+          type: number
+          format: double
+        bonus:
+          type: number
+          format: double
+        commission:
+          type: number
+          format: double
+      example:
+        salary: 52750.0
+        bonus: 1000.0
+        commission: 4220.0
+    ErrorResponse:
+      type: object
+      properties:
+        message:
+          type: string
+      example:
+        message: A message describing the error
+    EmployeeNotFound:
+      type: object
+      properties:
+        message:
+          type: string
+      example:
+        message: Employee could not be found
+    EmployeeNumber:
+      type: object
+      properties:
+        message:
+          type: string
+      example:
+        employeeNumber: "000010"
+    Departments:
+      type: string
+      enum:
+      - A00
+      - B01
+      - C01
+      - E01
+      - D11
+      - D21
+      - E11
+      - E21
+    Job:
+      type: string
+      enum:
+      - "FIELDREP"
+      - "OPERATOR"
+      - "CLERK   "
+      - "DESIGNER"
+      - "ANALYST "
+      - "SALESREP"
+      - "MANAGER "
+      - "PRES    "
+  parameters:
+    id:
+      name: id
+      in: path
+      required: true
+      style: simple
+      explode: false
+      schema:
+        type: string
+    department:
+      name: department
+      in: cookie
+      required: false
+      style: form
+      explode: true
+      schema:
+        $ref: '#/components/schemas/Departments'
+    job:
+      name: job
+      in: query
+      required: false
+      style: form
+      explode: true
+      schema:
+        $ref: '#/components/schemas/Job'
+  securitySchemes:
+    BasicAuth:
+      type: http
+      scheme: basic
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT

--- a/finish/README.md
+++ b/finish/README.md
@@ -5,7 +5,7 @@
 The EmployeesApi project allows users to create, read, update, and delete employees in the Db2 sample employee table (DSN8B10.EMP).
 
 ## Configuration
-To be able to connect to your Db2 instance in which you have the employee table sample installed you must first configure a `<db2Connection />` in this project. Create a file named `db2.xml` in the directory `./src/main/liberty/config`. Copy and customize the following contents into this file.
+To be able to connect to your Db2 instance in which you have the employee table sample installed you must first configure a `<zosconnect_db2connection />` in this project. Create a file named `db2.xml` in the directory `./src/main/liberty/config`. Copy and customize the following contents into this file.
 ```
 <server>
     <featureManager>

--- a/start/README.md
+++ b/start/README.md
@@ -5,7 +5,7 @@
 The EmployeesApi-base project can be enhanced to allow users to create, read, update, and delete employees in the Db2 sample employee table (DSN8B10.EMP).
 
 ## Configuration
-To be able to connect to your Db2 instance in which you have the employee table sample installed you must first configure a `<db2Connection />` in this project. Create a file named `db2.xml` in the directory `./src/main/liberty/config`. Copy and customize the following contents into this file.
+To be able to connect to your Db2 instance in which you have the employee table sample installed you must first configure a `<zosconnect_db2connection />` in this project. Create a file named `db2.xml` in the directory `./src/main/liberty/config`. Copy and customize the following contents into this file.
 ```
 <server>
     <featureManager>


### PR DESCRIPTION
Add a copy of the EmployeesApi OAS doc for use in the tutorial so when uses are creating the project from scratch we don't have to tell them to import the OAS from an existing project (which would look odd in a normal scenario). It's just a copy of the OAS from the finish project. Plus a couple of readme updates for the connection element name.